### PR TITLE
Add comprehensive e2e tests for MCP server

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -71,14 +71,6 @@ func initializeMCPServer(t *testing.T, server *mcpServer) {
 	// Send initialize request
 	initReq := jsonRPCRequest{
 		Method: "initialize",
-		Params: map[string]interface{}{
-			"protocolVersion": "0.1.0",
-			"capabilities":    map[string]interface{}{},
-			"clientInfo": map[string]interface{}{
-				"name":    "test-client",
-				"version": "1.0.0",
-			},
-		},
 	}
 	server.sendRequest(t, initReq)
 


### PR DESCRIPTION
## Summary
- Add end-to-end tests for MCP server using real stdio communication
- Test both list_tables and describe_tables tools with JSON-RPC 2.0 protocol
- Verify server correctly handles the complete MCP protocol flow

## Test plan
- [x] Run `go test -v -run TestE2E` to execute all e2e tests
- [x] Verify tests pass with Docker MySQL instance running
- [x] Confirm proper MCP protocol handshake (initialize/initialized)
- [x] Validate exact response format matching

🤖 Generated with [Claude Code](https://claude.ai/code)