### PR TITLE
Add ARM64 support to Docker workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add linux/arm64 platform support to Docker build workflow alongside existing linux/amd64
- Enables multi-architecture Docker images for better compatibility with ARM-based systems (M1/M2 Macs, ARM servers)